### PR TITLE
Fix several bugs and security issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ This action runs a custom script in a cross-arch Python environment using
 By default an Ubuntu-based environment is used, but you can use a custom
 `Dockerfile` to use a different OS.
 
+## Security considerations
+
+This action executes a repository-provided script and can optionally build from
+a repository-provided `Dockerfile`. Treat both as trusted code that runs with
+the workflow job's permissions.
+
+Do not run this action on untrusted code in privileged contexts such as
+`pull_request_target`. Prefer `pull_request` for untrusted contributions, limit
+token permissions, and avoid exposing sensitive secrets to jobs that invoke
+this action.
+
 Here is an example demonstrating how to use it in a workflow with a matrix job:
 
 ```yaml

--- a/action.yaml
+++ b/action.yaml
@@ -147,15 +147,17 @@ runs:
       env:
         SCRIPT: ${{ inputs.executable }}
         PASS_ENV: ${{ inputs.pass_env }}
+        WORKSPACE: ${{ github.workspace }}
+        ARCHITECTURE: ${{ inputs.architecture }}
       run: |
         docker run \
           --rm \
-          -v $(pwd):/${{ github.workspace }} \
+          -v "$(pwd):$WORKSPACE" \
           -v /tmp/pip-cache:/root/.cache/pip \
-          -w ${{ github.workspace }} \
+          -w "$WORKSPACE" \
           $(echo "$PASS_ENV" | sed 's/\([^ ]\+\)/-e \1/g') \
           --net=host \
-          --platform linux/${{ inputs.architecture }} \
+          --platform "linux/$ARCHITECTURE" \
           localhost/cross-arch-python:latest \
           "/usr/local/bin/$SCRIPT"
 

--- a/action.yaml
+++ b/action.yaml
@@ -95,7 +95,7 @@ runs:
       uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: /tmp/.buildx-cache
-        key: cross-arch-python-${{ runner.os }}-${{ inputs.architecture }}-{{ inputs.ubuntu_version }}-${{ inputs.python_version }}
+        key: cross-arch-python-${{ runner.os }}-${{ inputs.architecture }}-${{ inputs.ubuntu_version }}-${{ inputs.python_version }}
 
     - name: Copy the script to the docker context
       shell: bash
@@ -132,7 +132,7 @@ runs:
       uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: /tmp/pip-cache
-        key: cross-arch-python-${{ runner.os }}-${{ inputs.architecture }}-{{ inputs.ubuntu_version }}-${{ inputs.python_version }}
+        key: cross-arch-python-${{ runner.os }}-${{ inputs.architecture }}-${{ inputs.ubuntu_version }}-${{ inputs.python_version }}
 
     # This ensures that the docker container has access to the pip cache.
     # Changing the user in the docker-run step causes it to fail due to

--- a/action.yaml
+++ b/action.yaml
@@ -70,11 +70,13 @@ runs:
 
     - name: Check inputs
       shell: bash
+      env:
+        DOCKERFILE: ${{ inputs.dockerfile }}
+        UBUNTU_VERSION: ${{ inputs.ubuntu_version }}
       run: |
-        if test -z "${{ inputs.dockerfile }}" -a -z "${{ inputs.ubuntu_version }}"; then \
-            echo "::error ::At least one of `dockerfile` or `ubuntu_version` should be set"; \
-            exit 1; \
-          fi; \
+        if test -z "$DOCKERFILE" -a -z "$UBUNTU_VERSION"; then
+          echo "::error ::At least one of 'dockerfile' or 'ubuntu_version' should be set"
+          exit 1
         fi
 
     - name: Set up QEMU

--- a/action.yaml
+++ b/action.yaml
@@ -156,7 +156,6 @@ runs:
           -v /tmp/pip-cache:/root/.cache/pip \
           -w "$WORKSPACE" \
           $(echo "$PASS_ENV" | sed 's/\([^ ]\+\)/-e \1/g') \
-          --net=host \
           --platform "linux/$ARCHITECTURE" \
           localhost/cross-arch-python:latest \
           "/usr/local/bin/$SCRIPT"

--- a/action.yaml
+++ b/action.yaml
@@ -101,13 +101,13 @@ runs:
       shell: bash
       env:
         SCRIPT: ${{ inputs.script }}
-        CONTEXT: ${{ inputs.dockerfile == '' && format('{0}/docker", github.action_path) || dirname(inputs.dockerfile) }}
+        CONTEXT: ${{ inputs.dockerfile == '' && format('{0}/docker', github.action_path) || dirname(inputs.dockerfile) }}
       run: cp -r "$SCRIPT" "$CONTEXT/"
 
     - name: Build image
       uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
       with:
-        context: ${{ inputs.dockerfile == '' && format('{0}/docker", github.action_path) || dirname(inputs.dockerfile) }}
+        context: ${{ inputs.dockerfile == '' && format('{0}/docker', github.action_path) || dirname(inputs.dockerfile) }}
         file: ${{ inputs.dockerfile == '' && format('{0}/docker/Dockerfile', github.action_path) || inputs.dockerfile }}
         platforms: linux/${{ inputs.architecture }}
         tags: localhost/cross-arch-python:latest

--- a/action.yaml
+++ b/action.yaml
@@ -145,7 +145,7 @@ runs:
     - name: Run the command
       shell: bash
       env:
-        SCRIPT: ${{ inputs.executable }}
+        SCRIPT: ${{ inputs.script }}
         PASS_ENV: ${{ inputs.pass_env }}
         WORKSPACE: ${{ github.workspace }}
         ARCHITECTURE: ${{ inputs.architecture }}

--- a/action.yaml
+++ b/action.yaml
@@ -150,12 +150,20 @@ runs:
         WORKSPACE: ${{ github.workspace }}
         ARCHITECTURE: ${{ inputs.architecture }}
       run: |
+        env_args=()
+        if test -n "$PASS_ENV"; then
+          read -r -a pass_env_items <<< "$PASS_ENV"
+          for pass_env_item in "${pass_env_items[@]}"; do
+            env_args+=(--env "$pass_env_item")
+          done
+        fi
+
         docker run \
           --rm \
           -v "$(pwd):$WORKSPACE" \
           -v /tmp/pip-cache:/root/.cache/pip \
           -w "$WORKSPACE" \
-          $(echo "$PASS_ENV" | sed 's/\([^ ]\+\)/-e \1/g') \
+          "${env_args[@]}" \
           --platform "linux/$ARCHITECTURE" \
           localhost/cross-arch-python:latest \
           "/usr/local/bin/$SCRIPT"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,11 +27,11 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 
 # Install pip
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION}
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_VERSION} -I
 
 RUN update-alternatives --install \
         /usr/local/bin/python python /usr/bin/python${PYTHON_VERSION} 1 && \
-    python -m pip install --upgrade --no-cache-dir pip
+    python -I -m pip install --upgrade --no-cache-dir pip
 
 COPY entrypoint /usr/local/bin/entrypoint
 COPY ${SCRIPT} /usr/local/bin/${SCRIPT}


### PR DESCRIPTION
- **Harden input validation shell step**

  Move dockerfile and ubuntu_version inputs into environment variables before executing the check. This avoids direct expression interpolation in the run block and fixes the stray extra `fi` that caused shell syntax errors.

- **Use env vars in docker run step**

  Expose workspace and architecture through step environment variables and reference those shell variables in the docker invocation. This removes direct GitHub expression interpolation from the run block.

- **Drop host network mode from docker run**

  Remove --net=host from the runtime container invocation so jobs use Docker default bridge networking. This reduces access to runner-local network surfaces while preserving outbound connectivity.

- **Use the correct script action input**

  Read SCRIPT from inputs.script instead of the non-existent inputs.executable field. This restores command execution inside the container and aligns with the action metadata definition.

- **Fix Ubuntu cache key interpolation**

  Restore the missing $ in both cache key expressions so Ubuntu version is included in cache partitioning. This prevents incompatible caches from being shared across different base-image versions.

- **Run Python in isolated mode**

  Invoke python with `-I` to prevent user site and environment path injection when used with the `pull_request_target` trigger.

- **Build docker env args without shell eval**

  Replace command-substitution based PASS_ENV handling with explicit bash array construction. This prevents argument injection through shell parsing while preserving support for multiple env assignments.

- **Fix default docker context expression**

  Correct the GitHub expression used for the default docker build context path by removing a stray quote. This restores path expansion when callers do not provide a custom Dockerfile.

- **Document untrusted code safety limits**

  Add a security considerations section to clarify that scripts and `Dockerfile`s executed by this action must be trusted. The docs now explicitly discourage privileged `pull_request_target` usage.